### PR TITLE
Add ExifCleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 * [UTD Anonymization Toolbox](http://cs.utdallas.edu/dspl/cgi-bin/toolbox/index.php?go=home)
 * [Amnesia](https://amnesia.openaire.eu/)
 * [Anonymizer](https://github.com/DivanteLtd/anonymizer)
+* [ExifCleaner - Desktop app to remove image metadata](https://exifcleaner.com)
 * [Open Anonymizer](https://sourceforge.net/projects/openanonymizer/)
 * [µArgus](http://neon.vb.cbs.nl/casc/mu.htm)
 * [Cornell Anonymization Toolkit](https://sourceforge.net/projects/anony-toolkit/)


### PR DESCRIPTION
Hello. I've created a free an open source desktop app to remove exif metadata from images. It's cross platform, and all you have to do is drag and drop the images onto the window. I hope it will make a useful addition to your list. The website is exifcleaner.com where you can find a link to the download and source code. Have a great day.